### PR TITLE
Finalize secret refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ Este projeto visa fornecer uma ponte robusta e eficiente entre clientes que util
   - [Começando](#começando)
     - [Pré-requisitos](#pré-requisitos)
     - [Instalação](#instalação)
-      - [Usando Docker (Recomendado para Início Rápido)](#usando-docker-recomendado-para-início-rápido)
+      - [Usando Docker (Produção)](#usando-docker-produo)
+      - [Desenvolvimento Local](#desenvolvimento-local)
       - [A partir do Código-Fonte](#a-partir-do-código-fonte)
     - [Configuração Essencial](#configuração-essencial)
     - [Execução](#execução)
@@ -71,9 +72,9 @@ Construído em Rust, o servidor foi desenvolvido com foco em performance (utiliz
 
 ### Instalação
 
-#### Usando Docker (Recomendado para Início Rápido)
+#### Usando Docker (Produção)
 
-O fluxo de implantação padrão utiliza o HashiCorp Vault para fornecer a senha do TypeDB por meio do Vault Agent. Após configurar o Vault com o AppRole e o segredo `kv/typedb-mcp-server/config`, coloque os arquivos `role_id.txt` e `secret_id.txt` no diretório `production-secrets/` e execute:
+O fluxo recomendado de produção utiliza o HashiCorp Vault para fornecer a senha do TypeDB através do Vault Agent. Configure um AppRole no Vault, armazene o segredo em `kv/typedb-mcp-server/config` e coloque os arquivos `role_id.txt` e `secret_id.txt` em `production-secrets/`. Em seguida execute:
 
 ```bash
 docker compose -f docker-compose.production.yml up -d --build
@@ -83,16 +84,16 @@ Esse compose inicia um Vault, o TypeDB e o servidor MCP. O Vault Agent roda no e
 
 Para detalhes sobre configuração do Vault e uso em produção, consulte [`README.docker.md`](./README.docker.md) e a seção [Instalação com Docker](/docs/user_guide/03_installation.md#2-usando-docker).
 
-##### Desenvolvimento Local
+#### Desenvolvimento Local
 
-Para um fluxo simplificado sem Vault, use `docker-compose.yml`. Crie `local-dev-secrets/password.txt` contendo a senha e execute:
+Para desenvolvimento local sem a complexidade do Vault, utilize `docker-compose.yml`. Crie o arquivo `local-dev-secrets/password.txt` com a senha desejada e execute:
 
 ```bash
 docker compose up -d --build
 ```
 
 
-O arquivo é montado como Docker Secret e a aplicação o lê via `TYPEDB_PASSWORD_FILE=/run/secrets/db_password`.
+O compose monta esse arquivo como um Docker Secret dentro do contêiner e a aplicação o lê através da variável `TYPEDB_PASSWORD_FILE=/run/secrets/db_password`.
 
 #### A partir do Código-Fonte
 

--- a/config.dev.toml
+++ b/config.dev.toml
@@ -1,9 +1,10 @@
 # Configurações para o ambiente de DESENVOLVIMENTO.
 # Estes valores são tipicamente usados com `docker-compose.yml` (não o de teste).
 # 
-# Para segredos como TYPEDB_PASSWORD, use o arquivo .env na raiz do projeto.
-# Consulte .env.example para as variáveis disponíveis.
-# TYPEDB_PASSWORD definida no .env (ou como variável de ambiente) será usada.
+# Para segredos de desenvolvimento utilize o arquivo `.env` ou um Docker Secret
+# lido via `TYPEDB_PASSWORD_FILE`. Consulte `.env.example` para as variáveis
+# disponíveis. A senha do TypeDB é lida do caminho indicado em
+# `TYPEDB_PASSWORD_FILE`.
 # 
 # Variáveis de ambiente podem sobrescrever qualquer valor definido aqui.
 # Ex: MCP_TYPEDB__ADDRESS="outro.host.dev:1729"

--- a/config.test.toml
+++ b/config.test.toml
@@ -14,7 +14,8 @@
 # Convenções:
 #   - Todas as chaves de configuração estão em `camelCase` para alinhar com
 #     `#[serde(rename_all = "camelCase")]` nas structs de `src/config.rs`.
-#   - Para dados sensíveis como TYPEDB_PASSWORD, SEMPRE use variáveis de ambiente.
+#   - Para dados sensíveis, utilize variáveis de ambiente ou Docker Secrets
+#     lidos por `TYPEDB_PASSWORD_FILE`. Evite armazenar senhas diretamente.
 #
 # Precedência:
 #   Lembre-se que as variáveis de ambiente (prefixo MCP_) sempre sobrescreverão
@@ -74,7 +75,7 @@ address = "localhost:1729" # Ajustar conforme o ambiente de teste
 
 # Nome de usuário para autenticação com TypeDB.
 username = "admin"
-# A SENHA DO TYPEDB (`TYPEDB_PASSWORD`) DEVE ser fornecida via variável de ambiente.
+# A senha do TypeDB deve ser lida do arquivo apontado por `TYPEDB_PASSWORD_FILE`.
 
 # Habilita (true) ou desabilita (false) TLS para a conexão com o servidor TypeDB.
 tlsEnabled = false

--- a/tests/common/test_env.rs
+++ b/tests/common/test_env.rs
@@ -569,7 +569,7 @@ impl TestEnvironment {
 
             let vault_container =
                 format!("{}-{}", docker_env.project_name(), constants::VAULT_SERVICE_NAME);
-            let mut exec_cmd = |args: &[&str]| -> Result<String> {
+            let exec_cmd = |args: &[&str]| -> Result<String> {
                 let output = Command::new("docker")
                     .arg("exec")
                     .arg(&vault_container)

--- a/tests/integration/vault_integration_tests.rs
+++ b/tests/integration/vault_integration_tests.rs
@@ -1,4 +1,4 @@
-use crate::common::{constants, mcp_utils::get_text_from_call_result, test_env::TestEnvironment};
+use crate::common::{mcp_utils::get_text_from_call_result, test_env::TestEnvironment};
 use anyhow::{Context, Result};
 use serial_test::serial;
 use tracing::info;


### PR DESCRIPTION
## Summary
- update the Getting Started section to describe Vault-based production flow
- include a dedicated local development section
- update comments in config templates to reference `TYPEDB_PASSWORD_FILE`
- clean up lint warnings in the test suite

## Testing
- `cargo test --all --quiet` *(fails: command terminated)*

------
https://chatgpt.com/codex/tasks/task_b_6847ce0d25ac8322854547174b68ac0e