### PR TITLE
Fix IT secret injection

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -50,8 +50,8 @@ services:
       # --- LINHA MODIFICADA PARA LOGS DETALHADOS ---
       - RUST_LOG=${RUST_LOG_MCP:-trace,typedb_mcp_server=trace,axum=trace,hyper=trace,h2=trace,tower=trace,rustls=trace,tokio_rustls=trace}
       
-      # Senha para o TypeDB que o SERVIDOR MCP usará para se conectar.
-      - TYPEDB_PASSWORD=${TYPEDB_PASSWORD_TEST} # Usa a mesma senha definida para os serviços TypeDB
+      # Caminho do arquivo contendo a senha para o TypeDB que o SERVIDOR MCP usara para se conectar.
+      - TYPEDB_PASSWORD_FILE=/run/secrets/typedb_password_test
       
       # Endereço do TypeDB que o SERVIDOR MCP usará para se conectar.
       - MCP_TYPEDB__ADDRESS=${MCP_TYPEDB__ADDRESS} 
@@ -65,6 +65,9 @@ services:
       - source: mcp_approle_secret_id
         target: /run/secrets/mcp_approle_secret_id
         mode: 0400
+      - source: typedb_password_test_secret
+        target: typedb_password_test
+        mode: 0400
     
     entrypoint: [] # Sobrescreve entrypoint do Dockerfile
     command: >
@@ -72,7 +75,6 @@ services:
         set -e 
         echo '[DEBUG_MCP_SERVER_CMD] Script de entrada do typedb-mcp-server-it iniciado.'
         echo '[DEBUG_MCP_SERVER_CMD]   MCP_CONFIG_PATH (caminho do TOML) = \"$$MCP_CONFIG_PATH\"'
-        echo '[DEBUG_MCP_SERVER_CMD]   TYPEDB_PASSWORD (para o cliente TypeDB interno) = \"$$TYPEDB_PASSWORD\"'
         echo '[DEBUG_MCP_SERVER_CMD]   MCP_TYPEDB__ADDRESS (alvo do TypeDB para este MCP server) = \"$$MCP_TYPEDB__ADDRESS\"'
         echo '[DEBUG_MCP_SERVER_CMD]   RUST_LOG (para o servidor Rust) = \"$$RUST_LOG\"'
         echo '[DEBUG_MCP_SERVER_CMD]   TLS_ENABLED (para healthcheck Dockerfile) = \"$$TLS_ENABLED\"'
@@ -215,3 +217,5 @@ secrets:
     file: ./test-secrets/role_id.txt
   mcp_approle_secret_id:
     file: ./test-secrets/secret_id.txt
+  typedb_password_test_secret:
+    file: ./test-secrets/typedb_password.txt

--- a/test-secrets/typedb_password.txt
+++ b/test-secrets/typedb_password.txt
@@ -1,0 +1,1 @@
+password


### PR DESCRIPTION
## Summary
- provide default typedb password via secret file
- pass file path to integration container
- mount secret into typedb mcp server container

## Testing
- `cargo test --test integration -- --nocapture` *(fails: `No such file or directory (os error 2)`)*

------
https://chatgpt.com/codex/tasks/task_b_68489f6b109483228ac2ea425f04eb33